### PR TITLE
removed url validation from the 'fetch' function. 

### DIFF
--- a/src/app/services/url.service.ts
+++ b/src/app/services/url.service.ts
@@ -25,10 +25,6 @@ export class UrlService {
 
   fetch(url): Observable<any> {    
 
-    if (!this.isValidUrl(url)) {
-      return throwError("Invalid URL");
-    }
-
     var options = {
       "headers": new HttpHeaders().set('accept', "application/json")
     }


### PR DESCRIPTION
 if validation is required, it should be done separately.  (validation was causing fetch of relative URLs to fail.)